### PR TITLE
Elections - Candidate Profiles for Board Election

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,9 +43,6 @@
 			<a href="/who-are-dew.html" class="menu__link">Who are we?</a>
 						</li>
 				<li class="menu__item">
-			<a href="/drupalcamp-london.html" class="menu__link">DrupalCamp London</a>
-						</li>
-				<li class="menu__item">
 			<a href="/constitution-and-board.html" class="menu__link">Constitution and Board</a>
 						</li>
 				<li class="menu__item">
@@ -205,8 +202,7 @@ Contribute:&nbsp;
 
 
 <script src="./assets/js_5qUrUohzSc2peHTyskEn7OS02Pp3-sHOX30difUMKVE.js"></script>
-
-
+{{ page.scripts }}
 
 		</body>
 	</html>

--- a/assets/css_0hHz8SUrag7aEh1DKXBaPRDOUqJ6plYpg3kkXMhm9R8.css
+++ b/assets/css_0hHz8SUrag7aEh1DKXBaPRDOUqJ6plYpg3kkXMhm9R8.css
@@ -24,3 +24,5 @@ body.drag{cursor:move;}tr.region-title{font-weight:bold;}tr.region-message{color
 div.tree-child{background:url(/core/themes/stable/images/core/tree.png) no-repeat 11px center;}div.tree-child-last{background:url(/core/themes/stable/images/core/tree-bottom.png) no-repeat 11px center;}[dir="rtl"] div.tree-child,[dir="rtl"] div.tree-child-last{background-position:-65px center;}div.tree-child-horizontal{background:url(/core/themes/stable/images/core/tree.png) no-repeat -11px center;}
 .views-align-left{text-align:left;}.views-align-right{text-align:right;}.views-align-center{text-align:center;}.views-view-grid .views-col{float:left;}.views-view-grid .views-row{float:left;clear:both;width:100%;}.views-display-link + .views-display-link{margin-left:0.5em;}
 .paragraph--unpublished{background-color:#fff4f4;}
+.introduction #profiles p { font-size: 1em; }
+.gallery-item h3 { font-weight: bold; }

--- a/assets/isotope.js
+++ b/assets/isotope.js
@@ -1,0 +1,3 @@
+var iso = new Isotope('.l-gallery', { itemSelector: '.gallery-item'});
+//iso.layout();
+iso.shuffle();

--- a/elections.html
+++ b/elections.html
@@ -3,24 +3,21 @@ layout: default
 title: Drupal England and Wales | Elections
 page_title: Electing a Board
 header_image: header.jpg
-image_title: Drupal 9 is coming soon!
+image_title: Drupal 9 is here!
 image_button: Find out more
 image_link: https://www.drupal.org/docs/9
 next_button_text: Join Us!
 next_button_link: /join-dew.html
 ---
 <div>
-	<p>The specific mechanism for recording votes has not yet been decided upon.
-	Rachel Lawson is currently investigating options. Due to the current global
-	health crisis, things are understandably delayed. Calls for membership and,
-	importantly from an election point of view, calls for Board candidates remain
+	<p>We will be using an install of the open source software Helios to vote for the Board, candidates profiles will be posted soon, and the call for Board candidates remains
 	open, though there is currently no program for the initial election itself.
 	We will update this page when that changes.
 
 	<p>The originally intended election program remains 
 	<a href="https://docs.google.com/document/d/1bJL9TmT2osaP7yLunP3m3L8R5n5pckmfMgbo8vs_S4U/edit">minuted here</a>.</p>
 
-	<p>When elections do take place, the method for voting and counting will be
+	<p>When elections take place, the method for voting and counting will be
 	<a href="https://en.wikipedia.org/wiki/Instant-runoff_voting">“instant run-off voting”</a>.
 	The outright winner will be appointed Chairperson and the next six successful
 	candidates will be appointed Board members, role to be determined at the next

--- a/elections.html
+++ b/elections.html
@@ -8,11 +8,10 @@ image_button: Find out more
 image_link: https://www.drupal.org/docs/9
 next_button_text: Join Us!
 next_button_link: /join-dew.html
+scripts: <script src="https://isotope.metafizzy.co/isotope.pkgd.js"></script><script src="./assets/isotope.js"></script>
 ---
 <div>
-	<p>We will be using an install of the open source software Helios to vote for the Board, candidates profiles will be posted soon, and the call for Board candidates remains
-	open, though there is currently no program for the initial election itself.
-	We will update this page when that changes.
+	<p>We will be using an install of the open source software <a href="https://heliosvoting.org/" target="_blank">Helios</a> to vote for the Board, candidates profiles are listed <a href="#board-candidates">below</a>.</p>
 
 	<p>The originally intended election program remains 
 	<a href="https://docs.google.com/document/d/1bJL9TmT2osaP7yLunP3m3L8R5n5pckmfMgbo8vs_S4U/edit">minuted here</a>.</p>
@@ -22,5 +21,85 @@ next_button_link: /join-dew.html
 	The outright winner will be appointed Chairperson and the next six successful
 	candidates will be appointed Board members, role to be determined at the next
 	meeting of the Board.</p>
+
+	<div class="l-container">
+      <h2 class="section-title" id="board-candidates">DEW Board Candidates</h2>
+      <p>Below are the candidates for the board, click through to few more details about each candidate via their Drupal.org user profile, the list is presented in a random order after page load (if you have Javascript enabled).</p>
+
+    	<div class="l-gallery" id="profiles">
+          <div class="gallery-item">
+          	
+          	<h3>Greg Harvey</h3>
+          	<div><a href="https://www.drupal.org/u/greg.harvey" target="_blank"><img src="https://www.drupal.org/files/styles/grid-2-2x-square/public/user-pictures/picture-130383-1463646515.jpg?itok=PKXsRIwK" alt="Greg Harvey" /></a></div>
+          	<p><a href="https://www.drupal.org/u/greg.harvey" target="_blank">greg.harvey</a> on drupal.org</p>
+
+          </div>
+          <div class="gallery-item">
+          	
+          	<h3>Will Huggins</h3>
+          	<div><a href="https://www.drupal.org/u/zoocha-will" target="_blank"><img src="https://www.drupal.org/files/styles/grid-2-2x-square/public/user-pictures/picture-949106-1524651525.jpg?itok=KUenXyaG" alt="Will Huggins" /></a></div>
+          	<p><a href="https://www.drupal.org/u/zoocha-will" target="_blank">Zoocha Will</a> on drupal.org</p>
+
+          </div>
+          <div class="gallery-item">
+          	
+          	<h3>Andy Read</h3>
+          	<div><a href="https://www.drupal.org/u/Andy_Read" target="_blank"><img src="https://www.drupal.org/files/styles/grid-2-2x-square/public/user-pictures/picture-354426-1405981612.jpg?itok=u3JNNvBz" alt="Andy Read" /></a></div>
+          	<p><a href="https://www.drupal.org/u/Andy_Read" target="_blank">Andy_Read</a> on drupal.org</p>
+
+          </div>
+          <div class="gallery-item">
+          	
+          	<h3>George Hazlewood</h3>
+          	<div><a href="https://www.drupal.org/u/ghazlewood" target="_blank"><img src="https://www.drupal.org/files/styles/grid-2-2x-square/public/user-pictures/picture-2314-1548798243.jpg?itok=s1cxbQ7q" alt="George Hazlewood" /></a></div>
+          	<p><a href="https://www.drupal.org/u/ghazlewood" target="_blank">ghazlewood</a> on drupal.org</p>
+
+          </div>
+          <div class="gallery-item">
+          	
+          	<h3>Oliver Davies</h3>
+          	<div><a href="https://www.drupal.org/u/opdavies" target="_blank"><img src="https://www.drupal.org/files/styles/grid-2-2x-square/public/user-pictures/picture-381388-1573134071.jpg?itok=-qLBLldM" alt="Oliver Davies" /></a></div>
+          	<p><a href="https://www.drupal.org/u/opdavies" target="_blank">opdavies</a> on drupal.org</p>
+
+          </div>
+          <div class="gallery-item">
+          	
+          	<h3>Daniel Pickering</h3>
+          	<div><a href="https://www.drupal.org/u/ikit-claw" target="_blank"><img src="https://www.drupal.org/files/styles/grid-2-2x-square/public/user-pictures/picture-3285813-1558429079.jpg?itok=dmCLt3pG" alt="Daniel Pickering" /></a></div>
+          	<p><a href="https://www.drupal.org/u/ikit-claw" target="_blank">ikit-claw</a> on drupal.org</p>
+
+          </div>
+          <div class="gallery-item">
+          	
+          	<h3>Jon	Pollard</h3>
+          	<div><a href="https://www.drupal.org/u/jon-pollard" target="_blank"><img src="https://www.drupal.org/files/styles/grid-2-2x-square/public/user-pictures/picture-237971-1488965440.jpg?itok=tr3m4QA6" alt="Jon Pollard" /></a></div>
+          	<p><a href="https://www.drupal.org/u/jon-pollard" target="_blank">jon-pollard</a> on drupal.org</p>
+
+          </div>
+          <div class="gallery-item">
+          	
+          	<h3>Stewart Robinson</h3>
+          	<div><a href="https://www.drupal.org/u/stewsnooze" target="_blank"><img src="https://www.drupal.org/files/styles/grid-2-2x-square/public/user-pictures/picture-243255-1571846568.jpg?itok=1BI4bCIm" alt="Stewart Robinson" /></a></div>
+          	<p><a href="https://www.drupal.org/u/stewsnooze" target="_blank">stewsnooze</a> on drupal.org</p>
+
+          </div>
+          <div class="gallery-item">
+          	
+          	<h3>Alejandro Moreno Lopez</h3>
+          	<div><a href="https://www.drupal.org/u/alexmoreno" target="_blank"><img src="https://www.drupal.org/files/styles/grid-2-2x-square/public/user-pictures/picture-145609-1403082851.jpg?itok=_bNife3Q" alt="Alejandro Moreno Lopez" /></a></div>
+          	<p><a href="https://www.drupal.org/u/alexmoreno" target="_blank">alexmoreno</a> on drupal.org</p>
+
+          </div>
+          <!--
+          <div class="gallery-item">
+          	
+          	<h3>Firstname Surname</h3>
+          	<div><a href="https://www.drupal.org/u/" target="_blank"><img src="https://www.drupal.org/files/styles/grid-2-2x-square/public/default-avatar.png?itok=pCwA0iJh" alt="Firstname Surname" /></a></div>
+          	<p><a href="https://www.drupal.org/u/" target="_blank">username</a> on drupal.org</p>
+
+          </div>
+		  -->
+    	</div>
+    </div>
 
 </div>


### PR DESCRIPTION
Here's the updates for the candidate profiles for the board, I did also remove the link to Drupal Camp London from the main menu as it no longer seems to be relevant given the event has passed for 2020.

Random sort order uses Isotope from Metafizzy to make the nine profiles listed appear a different way each page load.